### PR TITLE
Use docker.io as gcr mirror only mantains the latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mirror.gcr.io/library/golang:1.13 as builder
+FROM docker.io/library/golang:1.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
```
$ podman pull mirror.gcr.io/library/golang:1.133
Trying to pull mirror.gcr.io/library/golang:1.13...
Error: Error initializing source docker://mirror.gcr.io/library/golang:1.13: Error reading manifest 1.13 in mirror.gcr.io/library/golang: manifest unknown: Failed to fetch "1.13" from request "/v2/library/golang/manifests/1.13"
```